### PR TITLE
Signup and Login endpoints

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,11 +1,14 @@
 from fastapi import FastAPI
 from src.routes import expense
+from src.routes.auth import signup, login
 
 # Note: the server runs on http://127.0.0.1:8000
 
 app = FastAPI()
 
 app.include_router(expense.router)
+app.include_router(signup.router)
+app.include_router(login.router)
 
 
 @app.get("/")

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,6 +6,8 @@ jinja2 == 3.0.2
 black == 21.9b0
 typing == 3.7.4.3
 pydantic == 1.8.2
-
 pymongo == 3.12.1
 dnspython == 2.1.0
+passlib==1.7.4
+python-jose==3.3.0
+cryptography==35.0.0

--- a/server/src/models/user.py
+++ b/server/src/models/user.py
@@ -1,4 +1,4 @@
-from pydantic import validator
+from pydantic import validator, Field
 from .mongo_db_model import MongoDBModel
 
 
@@ -13,3 +13,9 @@ class User(MongoDBModel):
         if "password" in values and v != values["password"]:
             raise ValueError("passwords do not match!")
         return v
+
+
+class UserInDB(MongoDBModel):
+    username: str
+    email: str
+    hashed_password: str

--- a/server/src/models/user.py
+++ b/server/src/models/user.py
@@ -1,4 +1,4 @@
-from pydantic import validator, Field
+from pydantic import validator
 from .mongo_db_model import MongoDBModel
 
 

--- a/server/src/routes/__init__.py
+++ b/server/src/routes/__init__.py
@@ -1,1 +1,3 @@
 from .expense import *
+from .auth.signup import *
+from .auth.login import *

--- a/server/src/routes/auth/login.py
+++ b/server/src/routes/auth/login.py
@@ -1,0 +1,1 @@
+# fastapi auth

--- a/server/src/routes/auth/login.py
+++ b/server/src/routes/auth/login.py
@@ -1,1 +1,97 @@
-# fastapi auth
+from datetime import datetime, timedelta
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose.exceptions import JWTError
+from ...models import User, UserInDB
+from ...database import user_collection
+from jose import jwt
+from passlib.context import CryptContext
+
+SECRET_KEY = "09d25e094faa6ca2556c818166b7a9563b93f7099f6f0f4caa6cf63b88e8d3e7"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+
+router = APIRouter()
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_user(username: str):
+    if (user := user_collection.find_one({"username": username})) is not None:
+        return UserInDB(**user)
+
+
+def authenticate_user(username: str, password: str):
+    user = get_user(username)
+    if not user:
+        return False
+    if not verify_password(password, user.hashed_password):
+        return False
+    return user
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+async def get_current_user(token: str = Depends(oauth2_scheme)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    td_username: str
+
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+        td_username = username
+    except JWTError:
+        raise credentials_exception
+
+    user = get_user(td_username)
+    if user is None:
+        raise credentials_exception
+
+    return user
+
+
+@router.post("/token")
+async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
+    user = authenticate_user(form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(
+        data={"sub": user.username}, expires_delta=access_token_expires
+    )
+
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.get("/users/me", response_model=UserInDB)
+def read_users_me(current_user: UserInDB = Depends(get_current_user)):
+    return current_user
+    # NOTE: this is just a placeholder

--- a/server/src/routes/auth/signup.py
+++ b/server/src/routes/auth/signup.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Body, status
+from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
+from ...models import User, UserInDB
+from ...database import user_collection
+from passlib.context import CryptContext
+
+router = APIRouter()
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+@router.post("/signup/", response_description="Add new user", response_model=UserInDB)
+def create_user(user: User = Body(...)):
+    new_user = UserInDB(
+        username=user.username,
+        email=user.email,
+        hashed_password=pwd_context.hash(user.password),
+    )
+    new_user = jsonable_encoder(new_user)
+    insert_user = user_collection.insert_one(new_user)
+    created_user = user_collection.find_one({"_id": insert_user.inserted_id})
+    return JSONResponse(status_code=status.HTTP_201_CREATED, content=created_user)


### PR DESCRIPTION
## Description ✍️

Implemented signup (create user) and login (verify creds) endpoints.

### Changes ⚙️

* Created UserInDB model at /server/models/user.py to store hashed passwords and user details on MongoDB
* Created signup endpoint at /server/routes/auth/signup.py to create user
* Created login endpoint at /server/routes/auth/login.py; implemented username/password based OAuth2 authentication
* Updated requirements.txt
* Included all new routers in /server/main.py

## Checklist 🗒

- [x] Ran `black .` to format code in `./server`
- [ ] Ran `npm run lint:fix` to format code in `./client`
- [ ] Assigned PR to all authors
- [x] Requested at least one reviewer
- [x] Linked the PR to its respective issue in ZenHub
- [x] Replaced the X below with the issue number

Closes #39
