### PR TITLE
exchange rate api called for adding/updating incomes/expenses

### DIFF
--- a/server/src/models/expense.py
+++ b/server/src/models/expense.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from datetime import date
 from .mongo_db_model import MongoDBModel
+from pydantic import validator
 
 
 class Expense(MongoDBModel):
@@ -16,6 +17,12 @@ class Expense(MongoDBModel):
     category: str
     sub_category: Optional[str] = None
 
+    @validator("exchange_rate")
+    def must_not_be_equal_negative_one(cls, exr):
+        if exr == -1:
+            raise ValueError("invalid currency")
+        return exr
+
 
 class UpdateExpenseModel(MongoDBModel):
     name: Optional[str]
@@ -29,3 +36,26 @@ class UpdateExpenseModel(MongoDBModel):
     location_y: Optional[float]
     category: Optional[str]
     sub_category: Optional[str]
+
+    @validator("exchange_rate")
+    def must_not_be_equal_negative_one(cls, exr):
+        if exr is not None and exr == -1:
+            raise ValueError("invalid currency")
+        return exr
+
+    class Config:
+        validate_assignment = True
+
+
+class AddExpense(MongoDBModel):
+    name: str
+    description: Optional[str] = None
+    date: date
+    price: float
+    currency: str
+    exchange_rate: Optional[float]
+    location: Optional[str] = None
+    location_x: Optional[float] = None
+    location_y: Optional[float] = None
+    category: str
+    sub_category: Optional[str] = None

--- a/server/src/models/income.py
+++ b/server/src/models/income.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from datetime import date
 from .mongo_db_model import MongoDBModel
+from pydantic import validator
 
 
 class Income(MongoDBModel):
@@ -15,6 +16,12 @@ class Income(MongoDBModel):
     location_y: Optional[float] = None
     category: Optional[str] = None
 
+    @validator("exchange_rate")
+    def must_not_be_equal_negative_one(cls, exr):
+        if exr == -1:
+            raise ValueError("invalid currency")
+        return exr
+
 
 class UpdateIncomeModel(MongoDBModel):
     name: Optional[str]
@@ -27,3 +34,25 @@ class UpdateIncomeModel(MongoDBModel):
     location_x: Optional[float]
     location_y: Optional[float]
     category: Optional[str]
+
+    @validator("exchange_rate")
+    def must_not_be_equal_negative_one(cls, exr):
+        if exr is not None and exr == -1:
+            raise ValueError("invalid currency")
+        return exr
+
+    class Config:
+        validate_assignment = True
+
+
+class AddIncome(MongoDBModel):
+    name: str
+    description: Optional[str] = None
+    date: date
+    amount: float
+    currency: str
+    exchange_rate: Optional[float] = None
+    location: Optional[str] = None
+    location_x: Optional[float] = None
+    location_y: Optional[float] = None
+    category: Optional[str] = None

--- a/server/src/routes/expense.py
+++ b/server/src/routes/expense.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter, Body, HTTPException, status
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
-from ..models import Expense, UpdateExpenseModel
+from pydantic.error_wrappers import ValidationError
+from ..models import Expense, UpdateExpenseModel, AddExpense
 from ..database import expense_collection
+from ..utils.currency import get_exchange_rate_to_cad
 
 router = APIRouter()
 
@@ -20,9 +22,24 @@ def get_expense_by_id(id):
 @router.post(
     "/expense/", response_description="Add new expense", response_model=Expense
 )
-def create_expense(expense: Expense = Body(...)):
-    expense = jsonable_encoder(expense)
-    new_expense = expense_collection.insert_one(expense)
+def create_expense(expense: AddExpense = Body(...)):
+    if expense.currency.lower() == "cad":
+        expense.exchange_rate = 1
+    else:
+        expense.exchange_rate = get_exchange_rate_to_cad(expense.currency)
+
+    expense_dict = {k: v for k, v in expense.dict().items()}
+
+    try:
+        insert_expense = Expense(**expense_dict)
+    except ValidationError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content=jsonable_encoder({"detail": exc.errors()}),
+        )
+
+    insert_expense = jsonable_encoder(insert_expense)
+    new_expense = expense_collection.insert_one(insert_expense)
     created_expense = expense_collection.find_one({"_id": new_expense.inserted_id})
     return JSONResponse(status_code=status.HTTP_201_CREATED, content=created_expense)
 
@@ -31,6 +48,18 @@ def create_expense(expense: Expense = Body(...)):
     "/expense/{id}", response_description="Update an expense", response_model=Expense
 )
 def update_expense(id, expense: UpdateExpenseModel = Body(...)):
+    if expense.currency is not None:
+        if expense.currency.lower() == "cad":
+            expense.exchange_rate = 1
+        else:
+            try:
+                expense.exchange_rate = get_exchange_rate_to_cad(expense.currency)
+            except ValidationError as exc:
+                return JSONResponse(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    content=jsonable_encoder({"detail": exc.errors()}),
+                )
+
     expense = {k: v for k, v in expense.dict().items() if v is not None}
     expense = jsonable_encoder(expense)
 


### PR DESCRIPTION
## Description ✍️

Calls exchange rate API to set `exchange_rate` field whenever a new income/expense is created or whenever the currency for an income/expense is updated.

### Changes ⚙️

* Updated income/expense creating and updating endpoints to call exchange rate api whenever the currency field is added or updated
* Created new `Income` and `Expense` models for income/expense creation with the `exchange_rate` field set to optional since this field is now set automatically through the api call
* Added validators to the `Income`, `UpdateIncome`, `Expense`, `UpdateExpense` models to check if the exchange rate api returns -1, signifying an invalid currency; `ValueError` is raised if this happens
* Implemented error handling at endpoints where api is called to ensure no invalid currency is recorded onto the database
* api is not called if currency is "cad" since it'll always be 1 in this case
* NOTE: currency field is case insensitive -> "cad", "CAD", "cAd" are all valid inputs

## Checklist 🗒

- [x] Ran `black .` to format code in `./server`
- [ ] Ran `npm run lint:fix` to format code in `./client`
- [x] Assigned PR to all authors
- [x] Requested at least one reviewer
- [x] Linked the PR to its respective issue in ZenHub
- [x] Replaced the X below with the issue number

Closes #66 
