### PR TITLE
Income Summary Modal

### DIFF
--- a/client/src/components/TablePage/TableComponent.jsx
+++ b/client/src/components/TablePage/TableComponent.jsx
@@ -6,6 +6,7 @@ import { MONTHS } from '../../utils/constants';
 import { theme } from '../../../theme';
 import ExpenseSummaryModal from '../../modals/ExpenseSummary';
 import IncomeSummaryModal from '../../modals/IncomeSummary'
+import ItemSummary from '../../modals/ItemSummary';
 
 const RightSwipe = () => {
   return (
@@ -16,8 +17,9 @@ const RightSwipe = () => {
 };
 
 const ListInputComponent = ({ obj, type }) => {
-  const [expenseSummaryModal, setExpenseSummaryModal] = useState(false);
-  const [incomeSummaryModal, setIncomeSummaryModal] = useState(false)
+  // const [expenseSummaryModal, setExpenseSummaryModal] = useState(false);
+  // const [incomeSummaryModal, setIncomeSummaryModal] = useState(false);
+  const [itemSummaryModal, setItemSummaryModal] = useState(false);
 
   const negative = type === 'Expenses' ? '-' : '';
   const userCategoriesExpenses = ['Food', 'Housing', 'Fun', 'Other', 'School'];
@@ -27,9 +29,10 @@ const ListInputComponent = ({ obj, type }) => {
     <>
       <List.Item
         title={<Text style={styles.subheader}>{obj.name}</Text>}
-        onPress={() => {
-          type === 'Expenses' ? setExpenseSummaryModal(true) : setIncomeSummaryModal(true)
-        }}
+        // onPress={() => {
+        //   type === "Expenses" ? setExpenseSummaryModal(true) : setIncomeSummaryModal(true)
+        // }}
+        onPress={() => { setItemSummaryModal(true) }}
         description={
           <View>
             <Text style={styles.text}>{obj.category}</Text>
@@ -48,7 +51,7 @@ const ListInputComponent = ({ obj, type }) => {
         )}
         style={styles.listItem}
       />
-      {expenseSummaryModal && (
+      {/* {expenseSummaryModal && (
         <ExpenseSummaryModal
           modalVisible={expenseSummaryModal}
           setModalVisible={setExpenseSummaryModal}
@@ -64,7 +67,18 @@ const ListInputComponent = ({ obj, type }) => {
           incomeData={obj}
           userCategories={userCategoriesIncomes}
         />
+      )} */}
+
+      {itemSummaryModal && (
+        <ItemSummary
+          modalVisible={itemSummaryModal}
+          setModalVisible={setItemSummaryModal}
+          data={obj}
+          userCategories={type === "Expenses" ? userCategoriesExpenses : userCategoriesIncomes}
+          type={type}
+        />
       )}
+
     </>
   );
 };

--- a/client/src/components/TablePage/TableComponent.jsx
+++ b/client/src/components/TablePage/TableComponent.jsx
@@ -5,6 +5,7 @@ import { Swipeable } from 'react-native-gesture-handler';
 import { MONTHS } from '../../utils/constants';
 import { theme } from '../../../theme';
 import ExpenseSummaryModal from '../../modals/ExpenseSummary';
+import IncomeSummaryModal from '../../modals/IncomeSummary'
 
 const RightSwipe = () => {
   return (
@@ -16,18 +17,18 @@ const RightSwipe = () => {
 
 const ListInputComponent = ({ obj, type }) => {
   const [expenseSummaryModal, setExpenseSummaryModal] = useState(false);
+  const [incomeSummaryModal, setIncomeSummaryModal] = useState(false)
 
   const negative = type === 'Expenses' ? '-' : '';
-  const userCategories = ['Food', 'Housing', 'Fun', 'Other', 'School'];
+  const userCategoriesExpenses = ['Food', 'Housing', 'Fun', 'Other', 'School'];
+  const userCategoriesIncomes = ['Main job', 'Part-time', 'Passive', 'Other'];
 
   return (
     <>
       <List.Item
         title={<Text style={styles.subheader}>{obj.name}</Text>}
         onPress={() => {
-          if (type === 'Expenses') {
-            setExpenseSummaryModal(true);
-          }
+          type === 'Expenses' ? setExpenseSummaryModal(true) : setIncomeSummaryModal(true)
         }}
         description={
           <View>
@@ -52,7 +53,16 @@ const ListInputComponent = ({ obj, type }) => {
           modalVisible={expenseSummaryModal}
           setModalVisible={setExpenseSummaryModal}
           expenseData={obj}
-          userCategories={userCategories}
+          userCategories={userCategoriesExpenses}
+        />
+      )}
+
+      {incomeSummaryModal && (
+        <IncomeSummaryModal
+          modalVisible={incomeSummaryModal}
+          setModalVisible={setIncomeSummaryModal}
+          incomeData={obj}
+          userCategories={userCategoriesIncomes}
         />
       )}
     </>

--- a/client/src/components/TablePage/TableComponent.jsx
+++ b/client/src/components/TablePage/TableComponent.jsx
@@ -5,7 +5,7 @@ import { Swipeable } from 'react-native-gesture-handler';
 import { MONTHS } from '../../utils/constants';
 import { theme } from '../../../theme';
 import ExpenseSummaryModal from '../../modals/ExpenseSummary';
-import IncomeSummaryModal from '../../modals/IncomeSummary'
+import IncomeSummaryModal from '../../modals/IncomeSummary';
 import ItemSummary from '../../modals/ItemSummary';
 
 const RightSwipe = () => {
@@ -32,7 +32,9 @@ const ListInputComponent = ({ obj, type }) => {
         // onPress={() => {
         //   type === "Expenses" ? setExpenseSummaryModal(true) : setIncomeSummaryModal(true)
         // }}
-        onPress={() => { setItemSummaryModal(true) }}
+        onPress={() => {
+          setItemSummaryModal(true);
+        }}
         description={
           <View>
             <Text style={styles.text}>{obj.category}</Text>
@@ -74,11 +76,10 @@ const ListInputComponent = ({ obj, type }) => {
           modalVisible={itemSummaryModal}
           setModalVisible={setItemSummaryModal}
           data={obj}
-          userCategories={type === "Expenses" ? userCategoriesExpenses : userCategoriesIncomes}
+          userCategories={type === 'Expenses' ? userCategoriesExpenses : userCategoriesIncomes}
           type={type}
         />
       )}
-
     </>
   );
 };

--- a/client/src/modals/IncomeSummary.jsx
+++ b/client/src/modals/IncomeSummary.jsx
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+import { StyleSheet, View, ScrollView, Text } from 'react-native';
+import StyledButton from '../components/StyledButton';
+import StyledTextInput from '../components/StyledTextInput';
+import StyledSelect from '../components/StyledSelect';
+import CustomModal from '../components/CustomModal';
+import AmountBox from '../components/AmountBox';
+import { theme } from '../../theme';
+
+const IncomeSummaryModal = ({ modalVisible, setModalVisible, incomeData, userCategories }) => {
+  const [income, setIncome] = useState(incomeData.price);
+  const [name, setName] = useState(incomeData.name);
+  const [date, setDate] = useState(incomeData.date);
+  const [category, setCategory] = useState(incomeData.category);
+  const [tag, setTag] = useState(incomeData.sub_category);
+  const [description, setDescription] = useState(incomeData.description);
+  const [location, setLocation] = useState(incomeData.location);
+  const [categoryDropdownVisible, setCategoryDropdownVisible] = useState(false);
+
+  const makeReadableDate = (preProcessedDate) => {
+    return `${
+      preProcessedDate.getMonth() + 1
+    }/${preProcessedDate.getDate()}/${preProcessedDate.getFullYear()}`;
+  };
+
+  const onSave = () => {
+    const updateObject = {
+      income,
+      name,
+      description,
+      date,
+      category,
+      sub_category: tag,
+      location,
+    };
+    console.log(updateObject);
+    console.log(incomeData);
+
+    setModalVisible(false);
+  };
+
+  return (
+    <CustomModal isModalVisible={modalVisible} setModalVisible={setModalVisible}>
+      <ScrollView>
+        <View style={styles.content}>
+          <Text style={styles.title}>Income Summary</Text>
+          <AmountBox
+            fields={[
+              income || 0.0,
+              name,
+              description,
+              makeReadableDate(date),
+              category || '',
+              tag,
+              location,
+            ]}
+          />
+          <StyledTextInput
+            label="Amount"
+            onChange={(newVal) => setIncome(newVal)}
+            keyboardType="numeric"
+            value={income.toString()}
+            required
+          />
+          <StyledTextInput
+            label="Name"
+            onChange={(newVal) => setName(newVal)}
+            keyboardType="default"
+            value={name}
+            required
+          />
+          <StyledTextInput
+            onChange={(newVal) => setDescription(newVal)}
+            keyboardType="default"
+            label="Description"
+            placeholder="Optional..."
+            value={description}
+            multiline
+          />
+          <StyledTextInput
+            label="Date"
+            onChange={(newVal) => setDate(newVal)}
+            keyboardType="default"
+            value={makeReadableDate(date)}
+            required
+          />
+          <StyledSelect
+            label="Category"
+            categories={userCategories.map((cat, index) => {
+              return {
+                label: cat,
+                value: cat,
+                key: index,
+              };
+            })}
+            category={category}
+            setCategory={setCategory}
+            categoryDropdownVisible={categoryDropdownVisible}
+            setCategoryDropdownVisible={setCategoryDropdownVisible}
+            placeholder={incomeData.category}
+            required
+          />
+          <StyledTextInput
+            onChange={setTag}
+            keyboardType="default"
+            label="Tag"
+            placeholder="Optional..."
+          />
+          <StyledTextInput
+            onChange={(newVal) => setLocation(newVal)}
+            keyboardType="default"
+            label="Location"
+            placeholder="Optional..."
+            value={location}
+          />
+          <View
+            style={{
+              flexDirection: 'row',
+              justifyContent: 'center',
+              marginTop: 20,
+            }}>
+            <View style={styles.button}>
+              <StyledButton label="Cancel" onTap={() => setModalVisible(false)} />
+            </View>
+            <View style={styles.button}>
+              <StyledButton label="Save" onTap={() => onSave()} />
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+    </CustomModal>
+  );
+};
+
+const styles = StyleSheet.create({
+  content: {
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+  },
+  title: {
+    textAlign: 'center',
+    fontSize: 24,
+    marginBottom: 20,
+    fontWeight: 'bold',
+    color: theme.colors.primary,
+  },
+  button: {
+    marginHorizontal: 20,
+  },
+});
+
+export default IncomeSummaryModal;

--- a/client/src/modals/ItemSummary.jsx
+++ b/client/src/modals/ItemSummary.jsx
@@ -7,7 +7,6 @@ import CustomModal from '../components/CustomModal';
 import AmountBox from '../components/AmountBox';
 import { theme } from '../../theme';
 
-
 const ItemSummary = ({ modalVisible, setModalVisible, data, userCategories, type }) => {
   const [item, setItem] = useState(data.price);
   const [name, setName] = useState(data.name);

--- a/client/src/modals/ItemSummary.jsx
+++ b/client/src/modals/ItemSummary.jsx
@@ -7,7 +7,7 @@ import CustomModal from '../components/CustomModal';
 import AmountBox from '../components/AmountBox';
 import { theme } from '../../theme';
 
-//same as incomeSummary and expenseSummary, takes in type to decide what labels to print
+
 const ItemSummary = ({ modalVisible, setModalVisible, data, userCategories, type }) => {
   const [item, setItem] = useState(data.price);
   const [name, setName] = useState(data.name);
@@ -18,8 +18,8 @@ const ItemSummary = ({ modalVisible, setModalVisible, data, userCategories, type
   const [location, setLocation] = useState(data.location);
   const [categoryDropdownVisible, setCategoryDropdownVisible] = useState(false);
 
-  const labelName = type === "Expenses" ? "Price" : "Amount"
-  const labelTitle = type === "Expenses" ? "Expense" : "Income"
+  const labelName = type === 'Expenses' ? 'Price' : 'Amount';
+  const labelTitle = type === 'Expenses' ? 'Expense' : 'Income';
 
   const makeReadableDate = (preProcessedDate) => {
     return `${

--- a/client/src/modals/ItemSummary.jsx
+++ b/client/src/modals/ItemSummary.jsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import { StyleSheet, View, ScrollView, Text } from 'react-native';
+import StyledButton from '../components/StyledButton';
+import StyledTextInput from '../components/StyledTextInput';
+import StyledSelect from '../components/StyledSelect';
+import CustomModal from '../components/CustomModal';
+import AmountBox from '../components/AmountBox';
+import { theme } from '../../theme';
+
+//same as incomeSummary and expenseSummary, takes in type to decide what labels to print
+const ItemSummary = ({ modalVisible, setModalVisible, data, userCategories, type }) => {
+  const [item, setItem] = useState(data.price);
+  const [name, setName] = useState(data.name);
+  const [date, setDate] = useState(data.date);
+  const [category, setCategory] = useState(data.category);
+  const [tag, setTag] = useState(data.sub_category);
+  const [description, setDescription] = useState(data.description);
+  const [location, setLocation] = useState(data.location);
+  const [categoryDropdownVisible, setCategoryDropdownVisible] = useState(false);
+
+  const labelName = type === "Expenses" ? "Price" : "Amount"
+  const labelTitle = type === "Expenses" ? "Expense" : "Income"
+
+  const makeReadableDate = (preProcessedDate) => {
+    return `${
+      preProcessedDate.getMonth() + 1
+    }/${preProcessedDate.getDate()}/${preProcessedDate.getFullYear()}`;
+  };
+
+  const onSave = () => {
+    const updateObject = {
+      item,
+      name,
+      description,
+      date,
+      category,
+      sub_category: tag,
+      location,
+    };
+    console.log(updateObject);
+    console.log(data);
+
+    setModalVisible(false);
+  };
+
+  return (
+    <CustomModal isModalVisible={modalVisible} setModalVisible={setModalVisible}>
+      <ScrollView>
+        <View style={styles.content}>
+          <Text style={styles.title}>{labelTitle} Summary</Text>
+          <AmountBox
+            fields={[
+              item || 0.0,
+              name,
+              description,
+              makeReadableDate(date),
+              category || '',
+              tag,
+              location,
+            ]}
+          />
+          <StyledTextInput
+            label={labelName}
+            onChange={(newVal) => setItem(newVal)}
+            keyboardType="numeric"
+            value={item.toString()}
+            required
+          />
+          <StyledTextInput
+            label="Name"
+            onChange={(newVal) => setName(newVal)}
+            keyboardType="default"
+            value={name}
+            required
+          />
+          <StyledTextInput
+            onChange={(newVal) => setDescription(newVal)}
+            keyboardType="default"
+            label="Description"
+            placeholder="Optional..."
+            value={description}
+            multiline
+          />
+          <StyledTextInput
+            label="Date"
+            onChange={(newVal) => setDate(newVal)}
+            keyboardType="default"
+            value={makeReadableDate(date)}
+            required
+          />
+          <StyledSelect
+            label="Category"
+            categories={userCategories.map((cat, index) => {
+              return {
+                label: cat,
+                value: cat,
+                key: index,
+              };
+            })}
+            category={category}
+            setCategory={setCategory}
+            categoryDropdownVisible={categoryDropdownVisible}
+            setCategoryDropdownVisible={setCategoryDropdownVisible}
+            placeholder={data.category}
+            required
+          />
+          <StyledTextInput
+            onChange={setTag}
+            keyboardType="default"
+            label="Tag"
+            placeholder="Optional..."
+          />
+          <StyledTextInput
+            onChange={(newVal) => setLocation(newVal)}
+            keyboardType="default"
+            label="Location"
+            placeholder="Optional..."
+            value={location}
+          />
+          <View
+            style={{
+              flexDirection: 'row',
+              justifyContent: 'center',
+              marginTop: 20,
+            }}>
+            <View style={styles.button}>
+              <StyledButton label="Cancel" onTap={() => setModalVisible(false)} />
+            </View>
+            <View style={styles.button}>
+              <StyledButton label="Save" onTap={() => onSave()} />
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+    </CustomModal>
+  );
+};
+
+const styles = StyleSheet.create({
+  content: {
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+  },
+  title: {
+    textAlign: 'center',
+    fontSize: 24,
+    marginBottom: 20,
+    fontWeight: 'bold',
+    color: theme.colors.primary,
+  },
+  button: {
+    marginHorizontal: 20,
+  },
+});
+
+export default ItemSummary;


### PR DESCRIPTION
## Description ✍️

Implemented the income summary modal and matched styling with expense summary modal.

### Changes ⚙️

- User can view/edit income fields on clicking income item from table.
- The implementation of the `ExpenseSummaryModal` and `IncomeSummaryModal` were the same so I refactored both of them to a single `ItemSummaryModal`. The individual implementation is included and commented out if we require an individual implementation and need to revert.

![incomeModal](https://user-images.githubusercontent.com/83952444/144417946-d66e370e-e45a-44e0-ac18-0680b73b4bc5.jpg)

## Checklist 🗒

- [ ] Ran `black .` to format code in `./server`
- [x] Ran `npm run lint:fix` to format code in `./client`
- [x] Assigned PR to all authors
- [x] Requested at least one reviewer
- [x] Linked the PR to its respective issue in ZenHub
- [x] Replaced the X below with the issue number

Closes #77
